### PR TITLE
Prevent cycler from trying to rename birthday.png

### DIFF
--- a/Cycle/Cycler.sh
+++ b/Cycle/Cycler.sh
@@ -27,9 +27,13 @@ fi
 #Logo cycling
 # Iterate through files and decrease their filename by 1. Also track how many total logos are available.
 for f in *.png; do
-	echo Renaming $f to $(printf %02d $((10#${f%.*}-1)))
-	mv $f $(printf %02d $((10#${f%.*}-1))).png
-	count=$((++count))
+	if [[ $f = "birthday.png" ]]; then
+		continue
+	else
+		echo Renaming $f to $(printf %02d $((10#${f%.*}-1)))
+		mv $f $(printf %02d $((10#${f%.*}-1))).png
+		count=$((++count))
+	fi
 done
 
 # Remove logo from main folder and rename it to sit at bottom of the rotation, put the lowest value image back in its place.


### PR DESCRIPTION
The cycler looped through all `*.png` files, including the `birthday.png`. This caused a bug where `birthday.png` would get renamed and the intended total # of files had an off by one error, making it so each run of `Cycler.sh` would result in one of the logo PNGs being deleted. 