### PR TITLE
Splash logo image generation from txt file

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -56,6 +56,7 @@ def generate():
     use_logo(index)
 
 def use_logo(index: int):
+    print(f"Using splash #{index}: '{text_options[index]}'.")
     shutil.copyfile(f"{cachedir}/{index}.png", f"{repodir}/logo.png")
 
 generate()

--- a/generate.py
+++ b/generate.py
@@ -1,0 +1,61 @@
+"""MIT License, see LICENSE for more details."""
+
+import os
+import random
+import shutil
+from os.path import abspath, dirname
+
+from PIL import Image, ImageDraw, ImageFont
+
+# Annoying dir path things
+repodir = dirname(abspath(__file__))
+if not os.path.isdir(f"{repodir}/cache"):
+    os.mkdir(f"{repodir}/cache")
+resourcedir = f"{repodir}/resources"
+cachedir = f"{repodir}/cache"
+
+with open(f"{resourcedir}/splashes.txt", "r") as f:
+    text_options = [i for i in f.read().splitlines() if i != ""]
+
+font_size = 48
+text_color = "rgb(255, 255, 0)"
+shadow_color = "rgb(59, 64, 2)"
+text_coords = (770, 450)
+angle = 20
+text_shadow = True
+shadow_offset = 5
+
+def generate():
+    # Choose random splash text
+    index = random.randint(0, len(text_options) - 1)
+    # Use cached image if it exists
+    if os.path.isfile(f"{cachedir}/{index}.png"):
+        return use_logo(index)
+    splash_text = text_options[index]
+    font = ImageFont.truetype(f"{resourcedir}/MinecraftRegular-Bmg3.otf", font_size)
+    img = Image.open(f"{resourcedir}/logo_clear.png")
+    original_size = img.size
+    # Rotate image before drawing text
+    img = img.rotate(360 - angle, expand=True)
+    d = ImageDraw.Draw(img)
+    # Draw text and shadow
+    if text_shadow:
+        d.text((text_coords[0] + shadow_offset, text_coords[1] + shadow_offset), splash_text, fill=shadow_color, anchor="ms", font=font)
+    d.text(text_coords, splash_text, fill=text_color, anchor="ms", font=font)
+    # Rotate image back to original angle
+    img = img.rotate(angle, expand=True)
+    # Mathy stuff (crop image back to original size)
+    coordinates = (
+        (img.size[0] - original_size[0]) / 2,
+        (img.size[1] - original_size[1]) / 2,
+        (img.size[0] + original_size[0]) / 2,
+        (img.size[1] + original_size[1]) / 2,
+    )
+    new = img.crop(coordinates)
+    new.save(f"{cachedir}/{index}.png")
+    use_logo(index)
+
+def use_logo(index: int):
+    shutil.copyfile(f"{cachedir}/{index}.png", f"{repodir}/logo.png")
+
+generate()

--- a/resources/minegrub-update.service
+++ b/resources/minegrub-update.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Cycles splash image for the minegrub grub theme.
+Description=minegrub theme splash update service
 
 [Service]
 ExecStart=/usr/bin/python3 /boot/grub2/themes/minegrub-theme/generate.py

--- a/resources/minegrub-update.service
+++ b/resources/minegrub-update.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Cycles splash image for the minegrub grub theme.
+
+[Service]
+ExecStart=/usr/bin/python3 /boot/grub2/themes/minegrub-theme/generate.py
+
+[Install]
+WantedBy=multi-user.target

--- a/resources/splashes.txt
+++ b/resources/splashes.txt
@@ -1,0 +1,47 @@
+I use Arch BTW!
+Now with 100% more Linux!
+GNU's not UNIX!
+Praise Tux!
+Wine is not an Emulator!
+I am Root!
+Still stuck in Vim!
+Won't sell your data!
+Now with Rust!
+Full of Distros!
+Do redistribute!
+May contain penguins!
+Support FOSS devs!
+Bailing out!
+Everything is a file!
+May contain systemd...
+Open source!
+Made in Finland!
+It's not a bug, it's a feature!
+It's GNU/Linux!
+Sudo rm -rf!
+Yes, do as I say!
+90% bug free!
+Not water proof!
+Used by billions!
+12345 is a bad password!
+Turing complete!
+Woah.
+I have a suggestion.
+pls fix
+beep beep
+Boop!
+Splash!
+[Insert splash text here]
+Made by "real" people!
+Viruses have no power here!
+No place like ~
+Used in space!
+No reboots required!
+Case sensitive!
+.exe won't work here!
+No ads!
+May contain spaghetti...
+No registry needed!
+Forward slashes only!
+No DLLs needed!
+127.0.0.1 > localhost :)


### PR DESCRIPTION
The python script generate.py will choose a random line from resources/splashes.txt and either generate and replace the current logo image, or copy the cached image from cache/ if it has been generated before.

I've included a minegrub-update.service for people using systemd to automatically run the script once after booting.

I'm not the best at writing instructions but here's a general outline:

Instructions for all users:
- Remove the ./Cycle/Cycler.sh crontab if you're using it
- Make sure ``python3`` (or an equivalent) and the ``pillow`` python package (``python-pillow`` in aur, ``pillow`` on pypi) are installed
- Run ``python path/to/generate.py`` (from anywhere) after boot using whatever method works for you
- To add new splash texts simply edit ``./resources/splashes.txt`` and add them to the **end** of the file (if you add it at the beginning or in the middle, some splashes may never get used because the image cashing uses the line of the file the splash is on)
- If you want to remove splashes you should reset the cache by deleting ``./cache``

Instructions for systemd users:
- Edit ``./resources/minegrub-update.service`` to use ``/boot/grub/...`` on line 5 if applicable
- Copy ``./resources/minegrub-update.service`` to ``/etc/systemd/system``
- Enable the service: ``systemctl enable minegrub-update.service``
- If it's not updating after rebooting (it won't update on the first reboot because it updates after you boot into your system), check ``systemctl status minegrub-update.service`` for any errors (it's likely pillow isn't installed in the correct scope)