### PR TITLE
Use splash hash rather than index for caching

### DIFF
--- a/minegrub/update_theme.py
+++ b/minegrub/update_theme.py
@@ -11,11 +11,10 @@ from PIL import Image, ImageDraw, ImageFont
 
 def update_splash() -> None:
     # Choose random splash text
-    index = random.randint(0, len(text_options) - 1)
+    splash_text= random.choice(text_options)
     # Use cached image if it exists
-    if os.path.isfile(f"{cachedir}/{index}.png"):
-        return use_logo(index)
-    splash_text = text_options[index]
+    if os.path.isfile(splash_file := cache_file_name(splash_text)):
+        return use_logo(splash_text, splash_file)
     font = ImageFont.truetype(f"{assetdir}/MinecraftRegular-Bmg3.otf", font_size)
     img = Image.open(f"{assetdir}/logo_clear.png")
     original_size = img.size
@@ -42,12 +41,15 @@ def update_splash() -> None:
         (img.size[1] + original_size[1]) / 2,
     )
     new = img.crop(coordinates)
-    new.save(f"{cachedir}/{index}.png")
-    use_logo(index)
+    new.save(splash_file)
+    use_logo(splash_text, splash_file)
 
-def use_logo(index: int):
-    print(f"Using splash #{index}: '{text_options[index]}'.")
-    shutil.copyfile(f"{cachedir}/{index}.png", f"{themedir}/logo.png")
+def use_logo(splash_text: str, splash_file: str):
+    print(f"Using splash {splash_file}: '{splash_text}'.")
+    shutil.copyfile(splash_file, f"{themedir}/logo.png")
+
+def cache_file_name(splash_text: str) -> str:
+    return f"{cachedir}/{hash(splash_text)}.png"
 
 def update_package_count() -> None:
     packages: int = int(


### PR DESCRIPTION
This allows to add/ remove splash texts while not "corrupting" the cache.

This has been tested on Arch which is the distro I use, BTW!