### PR TITLE
init.d (SysVinit) service for non-systemd distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ The `update_theme.py` script chooses a random line from `resources/splashes.txt`
 ### Update splash and "Packages Installed"...
 #### ...without systemd
 - Just run `python /boot/grub/themes/minegrub/update_theme.py` (from anywhere) after boot using whatever method works for you
+
+#### ...with init-d (SysVinit)
+- Just copy the `minecraft-grub.sh` under `/etc/init.d` as `minecraft-grub` then run `update-rc.d minecraft-grub defaults` as root privileges.
+```bash
+sudo cp -v "./minecraft-grub.sh" "/etc/init.d/minecraft-grub"
+sudo chmod u+x "/etc/init.d/minecraft-grub" # The file already permitted but to be sure, you can type.
+sudo update-rc.d minecraft-grub defaults
+```
+
 #### ...with systemd
 - Edit `./minegrub-update.service` to use `/boot/grub2/` on line 5 if applicable
 - Copy `./minegrub-update.service` to `/etc/systemd/system`

--- a/minecraft-grub.sh
+++ b/minecraft-grub.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+### BEGIN INIT INFO
+# Provides:          minecraft-grub
+# Required-Start:
+# Required-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:
+# Short-Description: Minecraft-Grub theme updater..
+#
+### END INIT INFO
+
+set -e
+
+PATH="/usr/bin:/bin:/sbin"
+NAME="minecraft-grub"
+DESC="Update the minecraft-grub theme."
+THEME_DIR="/boot/grub/themes/minegrub"
+
+case "${1}" in
+	"start"|"restart"|"reload"|"force-reload")
+		if command -v "python3" &> /dev/null ; then
+			python3 "${THEME_DIR}/update_theme.py" && exit 0 || exit 1
+		fi
+	;;
+	"stop")
+		echo "${0##*/}: done: nothing to do."
+		exit 0
+	;;
+	*)
+		echo "Usage: ${0##*/} start"
+		exit 3
+	;;
+esac

--- a/minecraft-grub.sh
+++ b/minecraft-grub.sh
@@ -15,7 +15,12 @@ set -e
 PATH="/usr/bin:/bin:/sbin"
 NAME="minecraft-grub"
 DESC="Update the minecraft-grub theme."
-THEME_DIR="/boot/grub/themes/minegrub"
+
+if [[ -d "/boot/grub2" ]] ; then
+	THEME_DIR="/boot/grub2/themes/minegrub"
+else
+	THEME_DIR="/boot/grub/themes/minegrub"
+fi
 
 case "${1}" in
 	"start"|"restart"|"reload"|"force-reload")


### PR DESCRIPTION
init.d (SysVinit) script for non-systemd distributions.

> Just copy the `minecraft-grub.sh` under `/etc/init.d` as `minecraft-grub` then run `update-rc.d minecraft-grub defaults`.

and that is it, it will be exec on every boot.
