### PR TITLE
use md5 hash of splash as cache filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The `update_theme.py` script chooses a random line from `resources/splashes.txt`
   - Install Pillow either with the python-pillow package from the AUR or with
     `sudo -H pip3 install pillow`
   - It's important to use `sudo -H`, because it needs to be available for the root user
-- To add new splash texts simply edit `./resources/splashes.txt` and add them to the end of the file (if you add it at the beginning or in the middle, some splashes may never get used because the image cashing uses the line of the file the splash is on)
+- To add new splash texts simply edit `./minegrub/assets/splashes.txt` and add them to the end of the file (if you add it at the beginning or in the middle, some splashes may never get used because the image cashing uses the line of the file the splash is on)
 - If you want to remove splashes you should reset the cache by deleting `/boot/grub/themes/minegrub/cache`
 - If you want to get a specific splash for the next boot, run `python update_theme.py "Splashing!"`
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The `update_theme.py` script chooses a random line from `resources/splashes.txt`
   - It's important to use `sudo -H`, because it needs to be available for the root user
 - To add new splash texts simply edit `./minegrub/assets/splashes.txt` and add them to the end of the file (if you add it at the beginning or in the middle, some splashes may never get used because the image cashing uses the line of the file the splash is on)
 - If you want to remove splashes you should reset the cache by deleting `/boot/grub/themes/minegrub/cache`
-- If you want to get a specific splash for the next boot, run `python update_theme.py "Splashing!"`
+- If you want to get a specific splash for the next boot, run `python update_theme.py 'Splashing!'`
 
 ### Update splash and "Packages Installed"...
 #### ...manually

--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ The `update_theme.py` script chooses a random line from `resources/splashes.txt`
   - Install Pillow either with the python-pillow package from the AUR or with
     `sudo -H pip3 install pillow`
   - It's important to use `sudo -H`, because it needs to be available for the root user
-- To add new splash texts simply edit `./minegrub/assets/splashes.txt` and add them to the end of the file (if you add it at the beginning or in the middle, some splashes may never get used because the image cashing uses the line of the file the splash is on)
-- If you want to remove splashes you should reset the cache by deleting `/boot/grub/themes/minegrub/cache`
+- To add new splash texts simply edit `./minegrub/assets/splashes.txt` and add them to the file.
 - If you want to get a specific splash for the next boot, run `python update_theme.py 'Splashing!'`
 
 ### Update splash and "Packages Installed"...

--- a/minegrub/update_theme.py
+++ b/minegrub/update_theme.py
@@ -9,17 +9,18 @@ from os.path import abspath, dirname
 from pathlib import Path
 
 from PIL import Image, ImageDraw, ImageFont
+import hashlib
 
 def update_splash(slogan: str) -> None:
     # Choose random splash text
     if slogan: # I just want it
         splash_text = slogan
     else:
-        index = random.randint(0, len(text_options) - 1)
+        splash_text = random.choice(text_options)
         # Use cached image if it exists
-        if os.path.isfile(f"{cachedir}/{index}.png"):
-            return use_logo(index)
-        splash_text = text_options[index]
+        splash_file = cache_file_name(splash_text)
+        if os.path.isfile(splash_file):
+            return use_logo(splash_text, splash_file)
     font = ImageFont.truetype(f"{assetdir}/MinecraftRegular-Bmg3.otf", font_size)
     img = Image.open(f"{assetdir}/logo_clear.png")
     original_size = img.size
@@ -51,12 +52,17 @@ def update_splash(slogan: str) -> None:
         print(f"Using splash from CLI: '{splash_text}'.")
         new.save(f"{themedir}/logo.png")
     else:
-        new.save(f"{cachedir}/{index}.png")
-        use_logo(index)
+        new.save(splash_file)
+        use_logo(splash_text, splash_file)
 
-def use_logo(index: int):
-    print(f"Using splash #{index}: '{text_options[index]}'.")
-    shutil.copyfile(f"{cachedir}/{index}.png", f"{themedir}/logo.png")
+def use_logo(splash_text: str, splash_file: str):
+    print(f"Using splash {splash_file}: '{splash_text}'.")
+    shutil.copyfile(splash_file, f"{themedir}/logo.png")
+
+def cache_file_name(splash_text: str) -> str:
+    h = hashlib.new('md5')
+    h.update(splash_text.encode())
+    return f"{cachedir}/{h.hexdigest()}.png"
 
 def update_package_count() -> None:
     packages: int = int(


### PR DESCRIPTION
Essentially #24, but using a suitable hash function. And forked just now, so there are no merge conflicts.