### PR TITLE
Update Splastext and Package count after hibernation as well

### DIFF
--- a/minegrub-update.service
+++ b/minegrub-update.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=minegrub theme splash update service
+After=hibternate.target
 
 [Service]
 ExecStart=/usr/bin/python3 /boot/grub/themes/minegrub/update_theme.py
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target hibernate.target


### PR DESCRIPTION
All this change does is trigger the ``update_theme.py`` script after waking up from hibernation. I find this logical to add, as you want the theme to cycle every time you see the screen, not just when your device reboots.

Thanks for the great theme though!