### PR TITLE
Fixed nixos-rebuild error with minegrub.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,10 @@
             cp *.png $out/grub/themes/minegrub
             cp *.pf2 $out/grub/themes/minegrub
             cp theme.txt $out/grub/themes/minegrub
+            cd ..
+            mkdir -p $out/grub/themes/minegrub/backgrounds
+            cd background_options
+            cp *.png $out/grub/themes/minegrub/backgrounds
           '';
         };
     in

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,8 @@
           '';
 
           buildPhase = optional customSplash ''
+            mkdir -p minegrub/backgrounds
+            cp background_options/*.png minegrub/backgrounds/
             echo "${splash}" > resources/splashes.txt
             python minegrub/update_theme.py
           '';

--- a/minegrub/assets/splashes.txt
+++ b/minegrub/assets/splashes.txt
@@ -1,50 +1,10 @@
-I use Arch BTW!
-Now with 100% more Linux!
-GNU's not UNIX!
-Praise Tux!
-Wine is not an Emulator!
-I am Root!
-Still stuck in Vim!
-Won't sell your data!
-Now with Rust!
-Full of Distros!
-Do redistribute!
-May contain penguins!
-Support FOSS devs!
-Bailing out!
-Everything is a file!
-May contain systemd...
-Open source!
-Made in Finland!
-It's not a bug, it's a feature!
-It's GNU/Linux!
-Sudo rm -rf!
-Yes, do as I say!
-90% bug free!
-Not water proof!
-Used by billions!
-12345 is a bad password!
-Turing complete!
-Woah.
-I have a suggestion.
-pls fix
-beep beep
-Boop!
-Splash!
-[Insert splash text here]
-Made by "real" people!
-Viruses have no power here!
-No place like ~
-Used in space!
-No reboots required!
-Case sensitive!
-.exe won't work here!
-No ads!
-May contain spaghetti...
-No registry needed!
-Forward slashes only!
-No DLLs needed!
-127.0.0.1 > localhost :)
-No caffeine!
-Zero calories!
-Do not eat!
+Per Aspera Ad Astra
+Do not go gentle into that good night.
+Look on my Works, ye Mighty, and despair!
+Ô temps ! suspends ton vol
+On n'est pas sérieux quand on a 0x11 ans.
+Le vent se lève... il faut tenter de vivre
+Demain, dès l'aube
+C'est une chose étrange à la fin que le monde.
+Mignonne, allons voir si la rose
+L'homme est libre au moment qu'il veut l'être.

--- a/minegrub/theme.txt
+++ b/minegrub/theme.txt
@@ -18,7 +18,7 @@ terminal-font: "Monocraft Regular 22"
 	# top pixmap is 17px in height 
 	# left pixmap is 6px in width 
 	# the text needs to be 3 pixels above and 3 pixels to the left
-	left = 50%-397 
+	left = 50%-497 
 	top = 40%+14
 	width = 800
 	height = 500
@@ -34,9 +34,9 @@ terminal-font: "Monocraft Regular 22"
 
 
 + boot_menu {
-	left = 50%-400
+	left = 50%-500
 	top = 40%
-	width = 800
+	width = 1000
 	height = 500
 
 	item_font = "Minecraft Regular 30"

--- a/minegrub/theme.txt
+++ b/minegrub/theme.txt
@@ -18,9 +18,9 @@ terminal-font: "Monocraft Regular 22"
 	# top pixmap is 17px in height 
 	# left pixmap is 6px in width 
 	# the text needs to be 3 pixels above and 3 pixels to the left
-	left = 50%-497 
+	left = 50%-597 
 	top = 40%+14
-	width = 800
+	width = 1200
 	height = 500
 
 	item_font = "Minecraft Regular 30"
@@ -34,9 +34,9 @@ terminal-font: "Monocraft Regular 22"
 
 
 + boot_menu {
-	left = 50%-500
+	left = 50%-600
 	top = 40%
-	width = 1000
+	width = 1200
 	height = 500
 
 	item_font = "Minecraft Regular 30"
@@ -90,7 +90,7 @@ terminal-font: "Monocraft Regular 22"
 	height = 54
 	width = 200
 
-	text = "Minegrub 2.0.0"
+	text = "The only way out is through."
 	font = "Minecraft Regular 30"
 	color = "white"
 }
@@ -102,7 +102,7 @@ terminal-font: "Monocraft Regular 22"
 	height = 54
 	width = 200
 
-	text = "Minegrub 2.0.0"
+	text = "The only way out is through."
 	font = "Minecraft Regular 30"
 	color = "#3f3f3f"
 }
@@ -114,7 +114,7 @@ terminal-font: "Monocraft Regular 22"
 	height = 54
 	width = 200
 
-	text = "The only way out is through."
+	text = "Where your fear is, there your task is."
 	font = "Minecraft Regular 30"
 	color = "white"
 }
@@ -126,7 +126,7 @@ terminal-font: "Monocraft Regular 22"
 	height = 54
 	width = 200
 
-	text = "The only way out is through."
+	text = "Where your fear is, there your task is."
 	font = "Minecraft Regular 30"
 	color = "#3f3f3f"
 }

--- a/minegrub/theme.txt
+++ b/minegrub/theme.txt
@@ -18,9 +18,9 @@ terminal-font: "Monocraft Regular 22"
 	# top pixmap is 17px in height 
 	# left pixmap is 6px in width 
 	# the text needs to be 3 pixels above and 3 pixels to the left
-	left = 50%-297 
+	left = 50%-397 
 	top = 40%+14
-	width = 600
+	width = 800
 	height = 500
 
 	item_font = "Minecraft Regular 30"
@@ -34,9 +34,9 @@ terminal-font: "Monocraft Regular 22"
 
 
 + boot_menu {
-	left = 50%-300
+	left = 50%-400
 	top = 40%
-	width = 600
+	width = 800
 	height = 500
 
 	item_font = "Minecraft Regular 30"
@@ -68,7 +68,7 @@ terminal-font: "Monocraft Regular 22"
 	###
 	############### CHANGE VALUE HERE ################
 
-	top = 40%+314
+	top = 40%+530
 
 	### Don't leave spaces in between the value
 	##################################################
@@ -114,7 +114,7 @@ terminal-font: "Monocraft Regular 22"
 	height = 54
 	width = 200
 
-	text = "647 Packages Installed"
+	text = "The only way out is through."
 	font = "Minecraft Regular 30"
 	color = "white"
 }
@@ -126,7 +126,7 @@ terminal-font: "Monocraft Regular 22"
 	height = 54
 	width = 200
 
-	text = "647 Packages Installed"
+	text = "The only way out is through."
 	font = "Minecraft Regular 30"
 	color = "#3f3f3f"
 }


### PR DESCRIPTION
I had a build error, after updating my flake.lock:
```shell
[root@nixos:/home/onyr/nixos-config]# nixos-rebuild build
building the system configuration...
warning: Git tree '/home/onyr/nixos-config' is dirty
warning: updating lock file '/home/onyr/nixos-config/flake.lock':
• Updated input 'minegrub-theme':
    'github:Lxtharia/minegrub-theme/46601b0b51ea35ee9f9410a3121e565100141ef1' (2023-09-27)
  → 'github:0nyr/minegrub-theme/1f2d8f1919747813fe40bca2a4b529025e3bd2eb' (2023-09-29)
warning: Git tree '/home/onyr/nixos-config' is dirty
error: builder for '/nix/store/8y22bjrb5qr3kc06jd8q4w172i6iqir1-minegrub-theme.drv' failed with exit code 1;
       last 10 log lines:
       > updateAutotoolsGnuConfigScriptsPhase
       > configuring
       > no configure script, doing nothing
       > building
       > Traceback (most recent call last):
       >   File "/build/source/minegrub/update_theme.py", line 134, in <module>
       >     update_background(bg_file)
       >   File "/build/source/minegrub/update_theme.py", line 104, in update_background
       >     list_background_files = [f for f in os.listdir(f"{themedir}/backgrounds/") if f[0] != '_']
       > FileNotFoundError: [Errno 2] No such file or directory: '/build/source/minegrub/backgrounds/'
       For full logs, run 'nix log /nix/store/8y22bjrb5qr3kc06jd8q4w172i6iqir1-minegrub-theme.drv'.
error: 1 dependencies of derivation '/nix/store/mxcjh6vln8jnplkxvppf7203ddmjk2hf-grub-config.xml.drv' failed to build
error: 1 dependencies of derivation '/nix/store/rlm7pxnm91nv73cg3h8w6bvfcwj4dpv8-install-grub.sh.drv' failed to build
error: 1 dependencies of derivation '/nix/store/m10ng065qs84il69d38vxgz98f7pdpy9-nixos-system-nixos-23.11.20230927.8a86b98.drv' failed to build

[root@nixos:/home/onyr/nixos-config]# nix log /nix/store/8y22bjrb5qr3kc06jd8q4w172i6iqir1-minegrub-theme.drv
warning: The interpretation of store paths arguments ending in `.drv` recently changed. If this command is now failing try again with '/nix/store/8y22bjrb5qr3kc06jd8q4w172i6iqir1-minegrub-theme.drv^*'
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/rzf2fjnsqbx9cwm0ra9fgqk1g8q9kdw8-source
source root is source
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
no configure script, doing nothing
@nix { "action": "setPhase", "phase": "buildPhase" }
building
Traceback (most recent call last):
  File "/build/source/minegrub/update_theme.py", line 134, in <module>
    update_background(bg_file)
  File "/build/source/minegrub/update_theme.py", line 104, in update_background
    list_background_files = [f for f in os.listdir(f"{themedir}/backgrounds/") if f[0] !=>
FileNotFoundError: [Errno 2] No such file or directory: '/build/source/minegrub/background
```

I fixed the flake.nix and tested it via a fork of the project. 
Now it works again.