### PR TITLE
Fix nix flake example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ sudo grub-mkconfig -o /boot/grub/grub.cfg
     nixosConfigurations.HOSTNAME = nixpkgs.lib.nixosSystem {
       modules = [
         ./configuration.nix
-        inputs.minegrub.nixosModules.default
+        inputs.minegrub-theme.nixosModules.default
       ];
     };
   }


### PR DESCRIPTION
When I was trying to get this installed on my NixOS system i realised that the nix flake example is wrong and throws an error when nixos-rebuild, so this is a quick correction. 

Also I did notice that this flake fails to build and I'm getting the same error as #54. I would like to take a look at that later and see if I can fix it.