### PR TITLE
improved dependency for fastfetch

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
 
           buildInputs = optional customSplash
             [
+              fastfetch
               (pkgs.python3.withPackages
                 (p: [ p.pillow ]))
             ];

--- a/minegrub/update_theme.py
+++ b/minegrub/update_theme.py
@@ -71,7 +71,7 @@ def get_output(command):
 
 def update_package_count() -> None:
     # Run Fastfetch and Neofetch in order
-    for command in [["fastfetch"], ["neofetch"]]:
+    for command in [["fastfetch", "-c", "neofetch"], ["neofetch"]]:
         try:
             output = get_output(command)
             break


### PR DESCRIPTION
Fastfetch supports extensive customization which means not every call to fastfetch includes a "Packages" line. However, fastfetch provides the `-c neofetch` argument which forces fastfetch to include the package count in its output.

Additionally, fastfetch in the flake buildInputs means that the user no longer has to have fastfetch (or neofetch) installed explicitly for the updating of the package count to work.