### PR TITLE
Correct setup instructions typo for choose_background.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ git clone https://github.com/Lxtharia/minegrub-theme.git
 ```
 - (optional) Choose a background
 ```
-./choose-background.sh  # or just copy a custom image to minegrub/background.png
+./choose_background.sh  # or just copy a custom image to minegrub/background.png
 ```
   - If you want to use the update script, copy an arbitrary number of images you would like to use to `minegrub/backgrounds/`. You can find some options in `background_options/` but you can also use your own images.
-  - If you do not want to use the update script or if you always want to use the same background, you can use `./choose-background.sh` or just copy a custom image to `minegrub/background.png`
+  - If you do not want to use the update script or if you always want to use the same background, you can use `./choose_background.sh` or just copy a custom image to `minegrub/background.png`
 
 - Copy the folder to your boot partition: (for your interest: `-ruv` = recursive, update, verbose)
 ```


### PR DESCRIPTION
The correct filename is `choose_background.sh`, not `choose-background.sh`.