### PR TITLE
add link to Minecraft World Loading KDE Splash

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 | --- | --- | --- |
 
 **Also check out these other projects:**
-| [Minecraft SDDM Theme](https://github.com/Davi-S/sddm-theme-minesddm) by Davi-S | [Minecraft Plymouth Theme](https://github.com/nikp123/minecraft-plymouth-theme) by nikp123 |
-| --- | --- |
+| [Minecraft SDDM Theme](https://github.com/Davi-S/sddm-theme-minesddm) by Davi-S | [Minecraft Plymouth Theme](https://github.com/nikp123/minecraft-plymouth-theme) by nikp123 | [Minecraft World Loading KDE Splash](https://github.com/Samsu-F/minecraftworldloading-kde-splash) by Samsu-F
+| --- | --- | --- |
 
 
 There is also a [Spanish translation](https://github.com/FeRChImoNdE/minegrub-theme-es)!


### PR DESCRIPTION
I made a KDE Splash to complete the startup team. Since you already link to other similar projects, I thought you might like to add this reference too. But you don't have to, feel free to reject this PR if you don't want to.