### PR TITLE
Add shebang to update_theme.py

### DIFF
--- a/minegrub/update_theme.py
+++ b/minegrub/update_theme.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """MIT License, see LICENSE for more details."""
 
 import os


### PR DESCRIPTION
Tried running this (it's marked executable) and got some really nasty stuff, almost couldn't kill it.

This tells most linux kernels to run this with python instead of whatever it decides to default to currently.