### PR TITLE
Update install_theme.sh to explicitly create `minegrub` dir in grub

### DIFF
--- a/install_theme.sh
+++ b/install_theme.sh
@@ -38,7 +38,9 @@ read -p "[?] Copy/Update the theme to '$theme_path'? [Y/n] " -en 1 copy_theme
 if [[ "$copy_theme" =~ y|Y || -z "$copy_theme" ]]; then
     echo "[INFO] => Copying the theme files to boot partition:"
     # copy recursive, update, verbose
-    cd $SCRIPT_DIR && cp -ruv ./minegrub $grub_path/themes/ | awk '$0 !~ /skipped/ { print "\t"$0 }'
+    cd $SCRIPT_DIR
+	mkdir -p $grub_path/themes/minegrub
+	cp -ruv ./minegrub $grub_path/themes/ | awk '$0 !~ /skipped/ { print "\t"$0 }'
 else
     echo "[INFO] [Skipping] Copying the theme files to boot partition"
 fi

--- a/install_theme.sh
+++ b/install_theme.sh
@@ -38,9 +38,7 @@ read -p "[?] Copy/Update the theme to '$theme_path'? [Y/n] " -en 1 copy_theme
 if [[ "$copy_theme" =~ y|Y || -z "$copy_theme" ]]; then
     echo "[INFO] => Copying the theme files to boot partition:"
     # copy recursive, update, verbose
-    cd $SCRIPT_DIR
-	mkdir -p $grub_path/themes/minegrub
-	cp -ruv ./minegrub $grub_path/themes/ | awk '$0 !~ /skipped/ { print "\t"$0 }'
+    cd $SCRIPT_DIR && mkdir -p $grub_path/themes/minegrub && cp -ruv ./minegrub $grub_path/themes/ | awk '$0 !~ /skipped/ { print "\t"$0 }'
 else
     echo "[INFO] [Skipping] Copying the theme files to boot partition"
 fi


### PR DESCRIPTION
This may have been something I only experienced on Ubuntu, but when running the `install_theme.sh` script the first time, all of the assets were not being copied into the correct location.
```
[?] Copy/Update the theme to '/boot/grub/themes/minegrub'? [Y/n] 
[INFO] => Copying the theme files to boot partition:
	'./minegrub' -> '/boot/grub/themes/'
	'./minegrub/Minecraft24.pf2' -> '/boot/grub/themes/Minecraft24.pf2'
	'./minegrub/Minecraft30.pf2' -> '/boot/grub/themes/Minecraft30.pf2'
	'./minegrub/Monocraft22.pf2' -> '/boot/grub/themes/Monocraft22.pf2'
	'./minegrub/assets' -> '/boot/grub/themes/assets'
	'./minegrub/assets/MinecraftRegular-Bmg3.otf' -> '/boot/grub/themes/assets/MinecraftRegular-Bmg3.otf'
	'./minegrub/assets/Monocraft.otf' -> '/boot/grub/themes/assets/Monocraft.otf'
	'./minegrub/assets/logo_clear.png' -> '/boot/grub/themes/assets/logo_clear.png'
	'./minegrub/assets/splashes.txt' -> '/boot/grub/themes/assets/splashes.txt'
	'./minegrub/background.png' -> '/boot/grub/themes/background.png'
	'./minegrub/backgrounds' -> '/boot/grub/themes/backgrounds'
	'./minegrub/backgrounds/.dummy_file' -> '/boot/grub/themes/backgrounds/.dummy_file'
	'./minegrub/dirt.png' -> '/boot/grub/themes/dirt.png'
	'./minegrub/item_c.png' -> '/boot/grub/themes/item_c.png'
	'./minegrub/item_e.png' -> '/boot/grub/themes/item_e.png'
	'./minegrub/item_n.png' -> '/boot/grub/themes/item_n.png'
	'./minegrub/item_ne.png' -> '/boot/grub/themes/item_ne.png'
	'./minegrub/item_nw.png' -> '/boot/grub/themes/item_nw.png'
	'./minegrub/item_s.png' -> '/boot/grub/themes/item_s.png'
	'./minegrub/item_se.png' -> '/boot/grub/themes/item_se.png'
	'./minegrub/item_sw.png' -> '/boot/grub/themes/item_sw.png'
	'./minegrub/item_w.png' -> '/boot/grub/themes/item_w.png'
	'./minegrub/logo.png' -> '/boot/grub/themes/logo.png'
	'./minegrub/selected_item_c.png' -> '/boot/grub/themes/selected_item_c.png'
	'./minegrub/selected_item_e.png' -> '/boot/grub/themes/selected_item_e.png'
	'./minegrub/selected_item_n.png' -> '/boot/grub/themes/selected_item_n.png'
	'./minegrub/selected_item_ne.png' -> '/boot/grub/themes/selected_item_ne.png'
	'./minegrub/selected_item_nw.png' -> '/boot/grub/themes/selected_item_nw.png'
	'./minegrub/selected_item_s.png' -> '/boot/grub/themes/selected_item_s.png'
	'./minegrub/selected_item_se.png' -> '/boot/grub/themes/selected_item_se.png'
	'./minegrub/selected_item_sw.png' -> '/boot/grub/themes/selected_item_sw.png'
	'./minegrub/selected_item_w.png' -> '/boot/grub/themes/selected_item_w.png'
	'./minegrub/static_bar.png' -> '/boot/grub/themes/static_bar.png'
	'./minegrub/term_e.png' -> '/boot/grub/themes/term_e.png'
	'./minegrub/term_n.png' -> '/boot/grub/themes/term_n.png'
	'./minegrub/term_ne.png' -> '/boot/grub/themes/term_ne.png'
	'./minegrub/term_nw.png' -> '/boot/grub/themes/term_nw.png'
	'./minegrub/term_s.png' -> '/boot/grub/themes/term_s.png'
	'./minegrub/term_se.png' -> '/boot/grub/themes/term_se.png'
	'./minegrub/term_sw.png' -> '/boot/grub/themes/term_sw.png'
	'./minegrub/term_w.png' -> '/boot/grub/themes/term_w.png'
	'./minegrub/theme.txt' -> '/boot/grub/themes/theme.txt'
	'./minegrub/update_theme.py' -> '/boot/grub/themes/update_theme.py'
```
This was easily fixed by explicitly creating the `$grub_path/themes/minegrub` directory before copying over the assets.